### PR TITLE
feat: 날짜 별 결석 인원 조회 기능 (#27)

### DIFF
--- a/src/main/java/ministryofeducation/sideprojectspring/department/application/DepartmentService.java
+++ b/src/main/java/ministryofeducation/sideprojectspring/department/application/DepartmentService.java
@@ -4,7 +4,6 @@ import static ministryofeducation.sideprojectspring.personnel.domain.attendance.
 
 import java.time.LocalDate;
 import java.util.List;
-import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import ministryofeducation.sideprojectspring.department.domain.Department;
@@ -109,8 +108,8 @@ public class DepartmentService {
             .collect(Collectors.toList());
     }
 
-    public List<GroupAbsentInfoResponse> getGroupAbsentInfo(Long departmentId, Long groupId) {
-        return personnelRepository.findByAbsentPersonnel(departmentId, groupId, ABSENT).stream()
+    public List<GroupAbsentInfoResponse> getGroupAbsentInfo(Long departmentId, Long groupId, LocalDate absentDate) {
+        return personnelRepository.findByAbsentPersonnel(departmentId, groupId, absentDate).stream()
             .map(GroupAbsentInfoResponse::of)
             .collect(Collectors.toList());
     }
@@ -144,7 +143,6 @@ public class DepartmentService {
             .personnel(personnel)
             .build();
     }
-
     @Transactional
     public List<GroupAddMemberListResponse> addGroupMember(Long departmentId, Long groupId,
         GroupAddMemberListRequest requestDto) {

--- a/src/main/java/ministryofeducation/sideprojectspring/department/presentation/DepartmentController.java
+++ b/src/main/java/ministryofeducation/sideprojectspring/department/presentation/DepartmentController.java
@@ -1,5 +1,7 @@
 package ministryofeducation.sideprojectspring.department.presentation;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import ministryofeducation.sideprojectspring.department.application.DepartmentService;
@@ -17,11 +19,9 @@ import ministryofeducation.sideprojectspring.department.presentation.dto.respons
 import ministryofeducation.sideprojectspring.department.presentation.dto.response.GroupModifyResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -72,11 +72,13 @@ public class DepartmentController {
         return ResponseEntity.ok(responseDto);
     }
 
-    @GetMapping("/{departmentId}/{groupId}/absent")
+    @GetMapping("/{departmentId}/{groupId}/absent/{absentDate}")
     public ResponseEntity<List<GroupAbsentInfoResponse>> groupAbsentInfo(
         @PathVariable("departmentId") Long departmentId,
-        @PathVariable("groupId") Long groupId) {
-        List<GroupAbsentInfoResponse> responseDto = departmentService.getGroupAbsentInfo(departmentId, groupId);
+        @PathVariable("groupId") Long groupId,
+        @PathVariable("absentDate") String absentDate) {
+        List<GroupAbsentInfoResponse> responseDto = departmentService.getGroupAbsentInfo(departmentId, groupId,
+            LocalDate.parse(absentDate, DateTimeFormatter.ISO_DATE));
 
         return ResponseEntity.ok(responseDto);
     }

--- a/src/main/java/ministryofeducation/sideprojectspring/personnel/infrastructure/PersonnelRepository.java
+++ b/src/main/java/ministryofeducation/sideprojectspring/personnel/infrastructure/PersonnelRepository.java
@@ -1,5 +1,6 @@
 package ministryofeducation.sideprojectspring.personnel.infrastructure;
 
+import java.time.LocalDate;
 import java.util.List;
 import ministryofeducation.sideprojectspring.personnel.domain.Personnel;
 import ministryofeducation.sideprojectspring.personnel.domain.attendance.AttendanceCheck;
@@ -11,10 +12,10 @@ public interface PersonnelRepository extends JpaRepository<Personnel, Long> {
     List<Personnel> findAll();
     List<Personnel> findByDepartmentIdAndSmallGroupId(Long departmentId, Long smallGroupId);
     @Query(value = "select p from Personnel p join fetch p.attendanceList a "
-        + "where p.department.id = :departmentId and p.smallGroup.id = :smallGroupId and a.attendanceCheck = :attendanceCheck")
+        + "where p.department.id = :departmentId and p.smallGroup.id = :smallGroupId and a.attendanceDate = :absentDate and a.attendanceCheck = 'ABSENT'")
     List<Personnel> findByAbsentPersonnel(
         @Param(value = "departmentId") Long departmentId,
         @Param(value = "smallGroupId") Long smallGroupId,
-        @Param(value = "attendanceCheck") AttendanceCheck attendanceCheck);
+        @Param(value = "absentDate") LocalDate absentDate);
 
 }

--- a/src/test/java/ministryofeducation/sideprojectspring/unit/Personnel/infrastructure/PersonnelRepositoryTest.java
+++ b/src/test/java/ministryofeducation/sideprojectspring/unit/Personnel/infrastructure/PersonnelRepositoryTest.java
@@ -100,6 +100,8 @@ class PersonnelRepositoryTest {
     @Test
     void 그룹_내_결석인원을_조회한다() {
         //given
+        LocalDate absentDate = LocalDate.of(2023, 12, 26);
+
         Department department = Department.createDepartment(1l, "department", 20);
         departmentRepository.save(department);
 
@@ -111,12 +113,12 @@ class PersonnelRepositoryTest {
         Personnel personnel3 = testPersonnel(3l, "test3", department, smallGroup);
         personnelRepository.saveAll(List.of(personnel1, personnel2, personnel3));
 
-        Attendance attendance1 = createAttendance(1l, LocalDate.now(), ABSENT, department, personnel1);
-        Attendance attendance2 = createAttendance(2l, LocalDate.now(), ABSENT, department, personnel3);
+        Attendance attendance1 = createAttendance(1l, absentDate, ABSENT, department, personnel1);
+        Attendance attendance2 = createAttendance(2l, absentDate, ABSENT, department, personnel3);
         attendanceRepository.saveAll(List.of(attendance1, attendance2));
 
         //when
-        List<Personnel> groupAbsentInfoResponse = personnelRepository.findByAbsentPersonnel(department.getId(), smallGroup.getId(), ABSENT);
+        List<Personnel> groupAbsentInfoResponse = personnelRepository.findByAbsentPersonnel(department.getId(), smallGroup.getId(), absentDate);
 
         //then
         assertThat(groupAbsentInfoResponse).hasSize(2)

--- a/src/test/java/ministryofeducation/sideprojectspring/unit/department/application/DepartmentServiceTest.java
+++ b/src/test/java/ministryofeducation/sideprojectspring/unit/department/application/DepartmentServiceTest.java
@@ -193,17 +193,18 @@ class DepartmentServiceTest {
     @Test
     void 그룹_내_결석인원을_조회한다() {
         //given
+        LocalDate absentDate = LocalDate.of(2023, 12, 26);
         Department department = Department.createDepartment(1l, "department", 20);
         SmallGroup smallGroup = SmallGroup.createSmallGroup(1l, "smallGroup", "leader", department);
         Personnel personnel1 = testPersonnel(1l, "test1", department, smallGroup);
         Personnel personnel2 = testPersonnel(2l, "test2", department, smallGroup);
 
-        given(personnelRepository.findByAbsentPersonnel(anyLong(), anyLong(), any(AttendanceCheck.class)))
+        given(personnelRepository.findByAbsentPersonnel(anyLong(), anyLong(), any(LocalDate.class)))
             .willReturn(List.of(personnel1, personnel2));
 
         //when
         List<GroupAbsentInfoResponse> groupAbsentInfoResponse = departmentService.getGroupAbsentInfo(department.getId(),
-            smallGroup.getId());
+            smallGroup.getId(), absentDate);
 
         //then
         assertThat(groupAbsentInfoResponse).hasSize(2)

--- a/src/test/java/ministryofeducation/sideprojectspring/unit/department/presentation/DepartmentControllerTest.java
+++ b/src/test/java/ministryofeducation/sideprojectspring/unit/department/presentation/DepartmentControllerTest.java
@@ -5,15 +5,11 @@ import static org.mockito.BDDMockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import java.time.LocalDate;
 import java.util.List;
-import ministryofeducation.sideprojectspring.department.domain.Department;
-import ministryofeducation.sideprojectspring.department.domain.SmallGroup;
 import ministryofeducation.sideprojectspring.department.presentation.dto.request.GroupAbsentListRequest;
 import ministryofeducation.sideprojectspring.department.presentation.dto.request.GroupAbsentListRequest.AbsenteeInfo;
 import ministryofeducation.sideprojectspring.department.presentation.dto.request.GroupAddMemberListRequest;
-import ministryofeducation.sideprojectspring.department.presentation.dto.request.GroupAddMemberListRequest.AddMemberInfo;
 import ministryofeducation.sideprojectspring.department.presentation.dto.request.GroupAddRequest;
 import ministryofeducation.sideprojectspring.department.presentation.dto.request.GroupModifyRequest;
 import ministryofeducation.sideprojectspring.department.presentation.dto.response.DepartmentInfoResponse;
@@ -25,7 +21,6 @@ import ministryofeducation.sideprojectspring.department.presentation.dto.respons
 import ministryofeducation.sideprojectspring.department.presentation.dto.response.GroupAddResponse;
 import ministryofeducation.sideprojectspring.department.presentation.dto.response.GroupInfoResponse;
 import ministryofeducation.sideprojectspring.department.presentation.dto.response.GroupModifyResponse;
-import ministryofeducation.sideprojectspring.personnel.domain.Personnel;
 import ministryofeducation.sideprojectspring.unit.ControllerTest;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -176,11 +171,11 @@ class DepartmentControllerTest extends ControllerTest {
             .phone("010-0000-0002")
             .build();
 
-        given(departmentService.getGroupAbsentInfo(anyLong(), anyLong()))
+        given(departmentService.getGroupAbsentInfo(anyLong(), anyLong(), any(LocalDate.class)))
             .willReturn(List.of(groupAbsentInfoResponse1, groupAbsentInfoResponse2));
 
         //when
-        ResultActions perform = mockMvc.perform(get("/{departmentId}/{groupId}/absent", anyLong(), anyLong()));
+        ResultActions perform = mockMvc.perform(get("/{departmentId}/{groupId}/absent/{absentDate}", 1l, 1l, "2023-12-26"));
 
         //then
         perform


### PR DESCRIPTION
## 연관 이슈
#27 

## 설명
- 기존 결석 인원 조회 로직에 날짜 별로 조회할 수 있도록 수정
- 기존 테스트 코드 수정