### PR TITLE
feat: 부서 별 통합 출석체크 기능 (#33)

### DIFF
--- a/src/main/java/ministryofeducation/sideprojectspring/department/application/DepartmentService.java
+++ b/src/main/java/ministryofeducation/sideprojectspring/department/application/DepartmentService.java
@@ -180,6 +180,14 @@ public class DepartmentService {
             .collect(Collectors.toList());
     }
 
+    private Personnel changePersonnelSmallGroup(AddMemberInfo member, Department department, SmallGroup smallGroup) {
+        Personnel personnel = personnelRepository.findById(member.getId())
+            .orElseThrow(() -> new IllegalArgumentException());
+        personnel.changeSmallGroup(smallGroup);
+
+        return personnel;
+    }
+
     @Transactional
     public List<DepartmentAttendanceMemberListResponse> attendanceDepartmentMember(Long departmentId,
         DepartmentAttendanceMemberListRequest requestDto) {
@@ -197,14 +205,6 @@ public class DepartmentService {
             .collect(Collectors.toList());
     }
 
-    private Personnel changePersonnelSmallGroup(AddMemberInfo member, Department department, SmallGroup smallGroup) {
-        Personnel personnel = personnelRepository.findById(member.getId())
-            .orElseThrow(() -> new IllegalArgumentException());
-        personnel.changeSmallGroup(smallGroup);
-
-        return personnel;
-    }
-
     private Personnel changePersonnelAttendance(AttendanceMemberInfo member, Department department) {
         Personnel personnel = personnelRepository.findById(member.getId())
             .orElseThrow(() -> new IllegalArgumentException());
@@ -217,10 +217,9 @@ public class DepartmentService {
             .build();
 
         Attendance recentAttendance = attendanceRepository.findTop1ByPersonnelIdOrderByAttendanceDateDesc(
-                personnel.getId())
-            .orElseThrow(() -> new IllegalArgumentException());
+                personnel.getId()).orElse(attendance);
 
-        if (recentAttendance != null && recentAttendance.getAttendanceDate() == attendance.getAttendanceDate()) {
+        if (recentAttendance.getAttendanceDate() == attendance.getAttendanceDate() && !personnel.getAttendanceList().isEmpty()) {
             recentAttendance.changeAttendanceCheck(ABSENT);
         } else {
             attendanceRepository.save(attendance);

--- a/src/main/java/ministryofeducation/sideprojectspring/department/application/DepartmentService.java
+++ b/src/main/java/ministryofeducation/sideprojectspring/department/application/DepartmentService.java
@@ -10,12 +10,15 @@ import ministryofeducation.sideprojectspring.department.domain.Department;
 import ministryofeducation.sideprojectspring.department.domain.SmallGroup;
 import ministryofeducation.sideprojectspring.department.infrastructure.DepartmentRepository;
 import ministryofeducation.sideprojectspring.department.infrastructure.SmallGroupRepository;
+import ministryofeducation.sideprojectspring.department.presentation.dto.request.DepartmentAttendanceMemberListRequest;
+import ministryofeducation.sideprojectspring.department.presentation.dto.request.DepartmentAttendanceMemberListRequest.AttendanceMemberInfo;
 import ministryofeducation.sideprojectspring.department.presentation.dto.request.GroupAbsentListRequest;
 import ministryofeducation.sideprojectspring.department.presentation.dto.request.GroupAbsentListRequest.AbsenteeInfo;
 import ministryofeducation.sideprojectspring.department.presentation.dto.request.GroupAddMemberListRequest;
 import ministryofeducation.sideprojectspring.department.presentation.dto.request.GroupAddMemberListRequest.AddMemberInfo;
 import ministryofeducation.sideprojectspring.department.presentation.dto.request.GroupAddRequest;
 import ministryofeducation.sideprojectspring.department.presentation.dto.request.GroupModifyRequest;
+import ministryofeducation.sideprojectspring.department.presentation.dto.response.DepartmentAttendanceMemberListResponse;
 import ministryofeducation.sideprojectspring.department.presentation.dto.response.DepartmentInfoResponse;
 import ministryofeducation.sideprojectspring.department.presentation.dto.response.DepartmentInfoResponse.SmallGroupInfo;
 import ministryofeducation.sideprojectspring.department.presentation.dto.response.DepartmentMemberListResponse;
@@ -56,7 +59,7 @@ public class DepartmentService {
         return DepartmentInfoResponse.of(smallGroupInfoList, departmentEnrollment, thisWeekAttendance);
     }
 
-    public List<DepartmentMemberListResponse> getDepartmentMemberList(Long departmentId, LocalDate todayDate){
+    public List<DepartmentMemberListResponse> getDepartmentMemberList(Long departmentId, LocalDate todayDate) {
         List<Personnel> personnelList = personnelRepository.findByDepartmentId(departmentId);
 
         return personnelList.stream()
@@ -65,7 +68,7 @@ public class DepartmentService {
 
     }
 
-    public GroupAddResponse addGroup(Long departmentId, GroupAddRequest requestDto){
+    public GroupAddResponse addGroup(Long departmentId, GroupAddRequest requestDto) {
         Department department = departmentRepository.findById(departmentId)
             .orElseThrow(() -> new IllegalArgumentException());
 
@@ -82,7 +85,7 @@ public class DepartmentService {
     }
 
     @Transactional
-    public GroupModifyResponse modifyGroup(Long departmentId, Long groupId, GroupModifyRequest requestDto){
+    public GroupModifyResponse modifyGroup(Long departmentId, Long groupId, GroupModifyRequest requestDto) {
         Department department = departmentRepository.findById(departmentId)
             .orElseThrow(() -> new IllegalArgumentException());
 
@@ -156,6 +159,7 @@ public class DepartmentService {
         personnel.addAttendance(attendance);
         return attendance;
     }
+
     @Transactional
     public List<GroupAddMemberListResponse> addGroupMember(Long departmentId, Long groupId,
         GroupAddMemberListRequest requestDto) {
@@ -176,10 +180,52 @@ public class DepartmentService {
             .collect(Collectors.toList());
     }
 
+    @Transactional
+    public List<DepartmentAttendanceMemberListResponse> attendanceDepartmentMember(Long departmentId,
+        DepartmentAttendanceMemberListRequest requestDto) {
+        List<AttendanceMemberInfo> memberList = requestDto.getAbsentMemberList();
+
+        Department department = departmentRepository.findById(departmentId)
+            .orElseThrow(() -> new IllegalArgumentException());
+
+        List<Personnel> personnelList = memberList.stream()
+            .map(member -> changePersonnelAttendance(member, department))
+            .collect(Collectors.toList());
+
+        return personnelList.stream()
+            .map(DepartmentAttendanceMemberListResponse::of)
+            .collect(Collectors.toList());
+    }
+
     private Personnel changePersonnelSmallGroup(AddMemberInfo member, Department department, SmallGroup smallGroup) {
         Personnel personnel = personnelRepository.findById(member.getId())
             .orElseThrow(() -> new IllegalArgumentException());
         personnel.changeSmallGroup(smallGroup);
+
+        return personnel;
+    }
+
+    private Personnel changePersonnelAttendance(AttendanceMemberInfo member, Department department) {
+        Personnel personnel = personnelRepository.findById(member.getId())
+            .orElseThrow(() -> new IllegalArgumentException());
+
+        Attendance attendance = Attendance.builder()
+            .attendanceDate(member.getAttendanceDate())
+            .attendanceCheck(ABSENT)
+            .department(department)
+            .personnel(personnel)
+            .build();
+
+        Attendance recentAttendance = attendanceRepository.findTop1ByPersonnelIdOrderByAttendanceDateDesc(
+                personnel.getId())
+            .orElseThrow(() -> new IllegalArgumentException());
+
+        if (recentAttendance != null && recentAttendance.getAttendanceDate() == attendance.getAttendanceDate()) {
+            recentAttendance.changeAttendanceCheck(ABSENT);
+        } else {
+            attendanceRepository.save(attendance);
+            personnel.addAttendance(attendance);
+        }
 
         return personnel;
     }

--- a/src/main/java/ministryofeducation/sideprojectspring/department/presentation/DepartmentController.java
+++ b/src/main/java/ministryofeducation/sideprojectspring/department/presentation/DepartmentController.java
@@ -5,10 +5,12 @@ import java.time.format.DateTimeFormatter;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import ministryofeducation.sideprojectspring.department.application.DepartmentService;
+import ministryofeducation.sideprojectspring.department.presentation.dto.request.DepartmentAttendanceMemberListRequest;
 import ministryofeducation.sideprojectspring.department.presentation.dto.request.GroupAbsentListRequest;
 import ministryofeducation.sideprojectspring.department.presentation.dto.request.GroupAddMemberListRequest;
 import ministryofeducation.sideprojectspring.department.presentation.dto.request.GroupAddRequest;
 import ministryofeducation.sideprojectspring.department.presentation.dto.request.GroupModifyRequest;
+import ministryofeducation.sideprojectspring.department.presentation.dto.response.DepartmentAttendanceMemberListResponse;
 import ministryofeducation.sideprojectspring.department.presentation.dto.response.DepartmentInfoResponse;
 import ministryofeducation.sideprojectspring.department.presentation.dto.response.DepartmentMemberListResponse;
 import ministryofeducation.sideprojectspring.department.presentation.dto.response.DepartmentNameResponse;
@@ -114,6 +116,16 @@ public class DepartmentController {
         @PathVariable("groupId") Long groupId) {
         List<GroupAddMemberListResponse> responseDto = departmentService.addGroupMember(departmentId,
             groupId, requestDto);
+
+        return ResponseEntity.ok(responseDto);
+    }
+
+    @PostMapping("/{departmentId}/attendance")
+    public ResponseEntity<List<DepartmentAttendanceMemberListResponse>> attendanceDepartmentMember(
+        @RequestBody DepartmentAttendanceMemberListRequest requestDto,
+        @PathVariable("departmentId") Long departmentId) {
+        List<DepartmentAttendanceMemberListResponse> responseDto = departmentService.attendanceDepartmentMember(
+            departmentId, requestDto);
 
         return ResponseEntity.ok(responseDto);
     }

--- a/src/main/java/ministryofeducation/sideprojectspring/department/presentation/dto/request/DepartmentAttendanceMemberListRequest.java
+++ b/src/main/java/ministryofeducation/sideprojectspring/department/presentation/dto/request/DepartmentAttendanceMemberListRequest.java
@@ -1,0 +1,36 @@
+package ministryofeducation.sideprojectspring.department.presentation.dto.request;
+
+import java.time.LocalDate;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DepartmentAttendanceMemberListRequest {
+
+    private List<AttendanceMemberInfo> absentMemberList;
+
+    @Builder
+    public DepartmentAttendanceMemberListRequest(List<AttendanceMemberInfo> absentMemberList) {
+        this.absentMemberList = absentMemberList;
+    }
+
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class AttendanceMemberInfo{
+        private Long id;
+        private String name;
+        private LocalDate attendanceDate;
+
+        @Builder
+        public AttendanceMemberInfo(Long id, String name, LocalDate attendanceDate) {
+            this.id = id;
+            this.name = name;
+            this.attendanceDate = attendanceDate;
+        }
+    }
+
+}

--- a/src/main/java/ministryofeducation/sideprojectspring/department/presentation/dto/response/DepartmentAttendanceMemberListResponse.java
+++ b/src/main/java/ministryofeducation/sideprojectspring/department/presentation/dto/response/DepartmentAttendanceMemberListResponse.java
@@ -1,0 +1,26 @@
+package ministryofeducation.sideprojectspring.department.presentation.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import ministryofeducation.sideprojectspring.personnel.domain.Personnel;
+
+@Getter
+public class DepartmentAttendanceMemberListResponse {
+
+    private Long id;
+    private String name;
+
+    @Builder
+    private DepartmentAttendanceMemberListResponse(Long id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    public static DepartmentAttendanceMemberListResponse of(Personnel personnel){
+        return DepartmentAttendanceMemberListResponse.builder()
+            .id(personnel.getId())
+            .name(personnel.getName())
+            .build();
+    }
+
+}

--- a/src/main/java/ministryofeducation/sideprojectspring/personnel/domain/Attendance.java
+++ b/src/main/java/ministryofeducation/sideprojectspring/personnel/domain/Attendance.java
@@ -40,8 +40,9 @@ public class Attendance extends BaseEntity {
     private Personnel personnel;
 
     @Builder
-    private Attendance(LocalDate attendanceDate, AttendanceCheck attendanceCheck, Department department,
+    private Attendance(Long id, LocalDate attendanceDate, AttendanceCheck attendanceCheck, Department department,
         Personnel personnel) {
+        this.id = id;
         this.attendanceDate = attendanceDate;
         this.attendanceCheck = attendanceCheck;
         this.department = department;
@@ -51,6 +52,7 @@ public class Attendance extends BaseEntity {
     public static Attendance createAttendance(Long id, LocalDate attendanceDate, AttendanceCheck attendanceCheck, Department department,
         Personnel personnel) {
         return Attendance.builder()
+            .id(id)
             .attendanceDate(attendanceDate)
             .attendanceCheck(attendanceCheck)
             .department(department)

--- a/src/main/java/ministryofeducation/sideprojectspring/personnel/domain/Attendance.java
+++ b/src/main/java/ministryofeducation/sideprojectspring/personnel/domain/Attendance.java
@@ -40,9 +40,8 @@ public class Attendance extends BaseEntity {
     private Personnel personnel;
 
     @Builder
-    private Attendance(Long id, LocalDate attendanceDate, AttendanceCheck attendanceCheck, Department department,
+    private Attendance(LocalDate attendanceDate, AttendanceCheck attendanceCheck, Department department,
         Personnel personnel) {
-        this.id = id;
         this.attendanceDate = attendanceDate;
         this.attendanceCheck = attendanceCheck;
         this.department = department;
@@ -52,11 +51,19 @@ public class Attendance extends BaseEntity {
     public static Attendance createAttendance(Long id, LocalDate attendanceDate, AttendanceCheck attendanceCheck, Department department,
         Personnel personnel) {
         return Attendance.builder()
-            .id(id)
             .attendanceDate(attendanceDate)
             .attendanceCheck(attendanceCheck)
             .department(department)
             .personnel(personnel)
             .build();
     }
+
+    public void changeAttendanceCheck(AttendanceCheck attendanceCheck){
+        this.attendanceCheck = attendanceCheck;
+    }
+
+    public void addPersonnel(Personnel personnel){
+        this.personnel = personnel;
+    }
+
 }

--- a/src/main/java/ministryofeducation/sideprojectspring/personnel/domain/Personnel.java
+++ b/src/main/java/ministryofeducation/sideprojectspring/personnel/domain/Personnel.java
@@ -108,6 +108,7 @@ public class Personnel extends BaseEntity {
 
     public void addAttendance(Attendance attendance) {
         this.getAttendanceList().add(attendance);
+        attendance.addPersonnel(this);
     }
 
     public AttendanceCheck todayAttendance(LocalDate today) {

--- a/src/main/java/ministryofeducation/sideprojectspring/personnel/infrastructure/AttendanceRepository.java
+++ b/src/main/java/ministryofeducation/sideprojectspring/personnel/infrastructure/AttendanceRepository.java
@@ -1,9 +1,11 @@
 package ministryofeducation.sideprojectspring.personnel.infrastructure;
 
 import java.time.LocalDate;
+import java.util.Optional;
 import ministryofeducation.sideprojectspring.personnel.domain.Attendance;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface AttendanceRepository extends JpaRepository<Attendance, Long> {
     Long countByAttendanceDateAndDepartmentId(LocalDate attendanceDate, Long departmentId);
+    Optional<Attendance> findTop1ByPersonnelIdOrderByAttendanceDateDesc(Long personnelId);
 }

--- a/src/test/java/ministryofeducation/sideprojectspring/unit/Personnel/infrastructure/AttendanceRepositoryTest.java
+++ b/src/test/java/ministryofeducation/sideprojectspring/unit/Personnel/infrastructure/AttendanceRepositoryTest.java
@@ -1,0 +1,71 @@
+package ministryofeducation.sideprojectspring.unit.Personnel.infrastructure;
+
+import static ministryofeducation.sideprojectspring.personnel.domain.attendance.AttendanceCheck.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.LocalDate;
+import java.util.Optional;
+import ministryofeducation.sideprojectspring.department.domain.Department;
+import ministryofeducation.sideprojectspring.department.infrastructure.DepartmentRepository;
+import ministryofeducation.sideprojectspring.personnel.domain.Attendance;
+import ministryofeducation.sideprojectspring.personnel.domain.Personnel;
+import ministryofeducation.sideprojectspring.personnel.domain.attendance.AttendanceCheck;
+import ministryofeducation.sideprojectspring.personnel.infrastructure.AttendanceRepository;
+import ministryofeducation.sideprojectspring.personnel.infrastructure.PersonnelRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@DataJpaTest
+@ActiveProfiles("test")
+class AttendanceRepositoryTest {
+
+    @Autowired
+    private AttendanceRepository attendanceRepository;
+
+    @Autowired
+    private PersonnelRepository personnelRepository;
+
+    @Autowired
+    private DepartmentRepository departmentRepository;
+
+    @DisplayName("가장 최근 출석 기록을 1개 불러온다.")
+    @Test
+    void findTop1ByPersonnelIdOrderByAttendanceDateDesc(){
+        //given
+        LocalDate recentDate = LocalDate.of(2024, 1, 30);
+
+        Personnel personnel = Personnel.builder()
+            .id(1l)
+            .name("test")
+            .build();
+        personnelRepository.save(personnel);
+
+        Department department = Department.builder()
+            .name("testDepartment")
+            .enrollment(10)
+            .build();
+        departmentRepository.save(department);
+
+        Attendance attendance = Attendance.builder()
+            .attendanceDate(recentDate)
+            .attendanceCheck(ABSENT)
+            .department(department)
+            .personnel(personnel)
+            .build();
+        attendanceRepository.save(attendance);
+
+        //when
+        Attendance recentAttendance = attendanceRepository.findTop1ByPersonnelIdOrderByAttendanceDateDesc(
+            personnel.getId()).get();
+
+        //then
+        assertThat(recentAttendance.getAttendanceDate()).isEqualTo(recentDate);
+        assertThat(recentAttendance.getAttendanceCheck()).isEqualTo(ABSENT);
+    }
+
+}

--- a/src/test/java/ministryofeducation/sideprojectspring/unit/Personnel/infrastructure/AttendanceRepositoryTest.java
+++ b/src/test/java/ministryofeducation/sideprojectspring/unit/Personnel/infrastructure/AttendanceRepositoryTest.java
@@ -19,8 +19,11 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 
 @DataJpaTest
+@Transactional(propagation = Propagation.NOT_SUPPORTED)
 @ActiveProfiles("test")
 class AttendanceRepositoryTest {
 

--- a/src/test/java/ministryofeducation/sideprojectspring/unit/department/application/DepartmentServiceTest.java
+++ b/src/test/java/ministryofeducation/sideprojectspring/unit/department/application/DepartmentServiceTest.java
@@ -14,12 +14,15 @@ import ministryofeducation.sideprojectspring.department.domain.Department;
 import ministryofeducation.sideprojectspring.department.domain.SmallGroup;
 import ministryofeducation.sideprojectspring.department.infrastructure.DepartmentRepository;
 import ministryofeducation.sideprojectspring.department.infrastructure.SmallGroupRepository;
+import ministryofeducation.sideprojectspring.department.presentation.dto.request.DepartmentAttendanceMemberListRequest;
+import ministryofeducation.sideprojectspring.department.presentation.dto.request.DepartmentAttendanceMemberListRequest.AttendanceMemberInfo;
 import ministryofeducation.sideprojectspring.department.presentation.dto.request.GroupAbsentListRequest;
 import ministryofeducation.sideprojectspring.department.presentation.dto.request.GroupAbsentListRequest.AbsenteeInfo;
 import ministryofeducation.sideprojectspring.department.presentation.dto.request.GroupAddMemberListRequest;
 import ministryofeducation.sideprojectspring.department.presentation.dto.request.GroupAddMemberListRequest.AddMemberInfo;
 import ministryofeducation.sideprojectspring.department.presentation.dto.request.GroupAddRequest;
 import ministryofeducation.sideprojectspring.department.presentation.dto.request.GroupModifyRequest;
+import ministryofeducation.sideprojectspring.department.presentation.dto.response.DepartmentAttendanceMemberListResponse;
 import ministryofeducation.sideprojectspring.department.presentation.dto.response.DepartmentInfoResponse;
 import ministryofeducation.sideprojectspring.department.presentation.dto.response.DepartmentMemberListResponse;
 import ministryofeducation.sideprojectspring.department.presentation.dto.response.DepartmentNameResponse;
@@ -333,6 +336,45 @@ class DepartmentServiceTest {
                 tuple("test2", ATTENDANCE),
                 tuple("test3", null)
             );
+    }
+
+    @Test
+    void 부서_내_모든_인원을_대상으로_출석체크를_한다() {
+        //given
+        LocalDate today = LocalDate.of(2024, 1, 31);
+
+        Department department = Department.createDepartment(1l, "department", 20);
+        Personnel personnel1 = testPersonnel(1l, "test1", department, null);
+        Personnel personnel2 = testPersonnel(2l, "test2", department, null);
+
+        AttendanceMemberInfo requestMemberInfo1 = AttendanceMemberInfo.builder()
+            .id(1l)
+            .name("test1")
+            .attendanceDate(today)
+            .build();
+        AttendanceMemberInfo requestMemberInfo2 = AttendanceMemberInfo.builder()
+            .id(2l)
+            .name("test2")
+            .attendanceDate(today)
+            .build();
+
+        DepartmentAttendanceMemberListRequest request = DepartmentAttendanceMemberListRequest.builder()
+            .absentMemberList(List.of(requestMemberInfo1, requestMemberInfo2))
+            .build();
+
+        given(departmentRepository.findById(anyLong())).willReturn(Optional.of(department));
+        given(personnelRepository.findById(anyLong()))
+            .willReturn(Optional.of(personnel1), Optional.of(personnel2));
+
+        //when
+        List<DepartmentAttendanceMemberListResponse> response = departmentService.attendanceDepartmentMember(
+            department.getId(), request);
+
+        //then
+        assertThat(response).hasSize(2);
+        assertThat(personnel1.getAttendanceList().get(0).getAttendanceCheck()).isEqualTo(ABSENT);
+        assertThat(personnel2.getAttendanceList().get(0).getAttendanceCheck()).isEqualTo(ABSENT);
+
     }
 
 }

--- a/src/test/java/ministryofeducation/sideprojectspring/unit/department/presentation/DepartmentControllerTest.java
+++ b/src/test/java/ministryofeducation/sideprojectspring/unit/department/presentation/DepartmentControllerTest.java
@@ -10,11 +10,13 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
+import ministryofeducation.sideprojectspring.department.presentation.dto.request.DepartmentAttendanceMemberListRequest;
 import ministryofeducation.sideprojectspring.department.presentation.dto.request.GroupAbsentListRequest;
 import ministryofeducation.sideprojectspring.department.presentation.dto.request.GroupAbsentListRequest.AbsenteeInfo;
 import ministryofeducation.sideprojectspring.department.presentation.dto.request.GroupAddMemberListRequest;
 import ministryofeducation.sideprojectspring.department.presentation.dto.request.GroupAddRequest;
 import ministryofeducation.sideprojectspring.department.presentation.dto.request.GroupModifyRequest;
+import ministryofeducation.sideprojectspring.department.presentation.dto.response.DepartmentAttendanceMemberListResponse;
 import ministryofeducation.sideprojectspring.department.presentation.dto.response.DepartmentInfoResponse;
 import ministryofeducation.sideprojectspring.department.presentation.dto.response.DepartmentInfoResponse.SmallGroupInfo;
 import ministryofeducation.sideprojectspring.department.presentation.dto.response.DepartmentMemberListResponse;
@@ -288,6 +290,37 @@ class DepartmentControllerTest extends ControllerTest {
         //when
         ResultActions perform = mockMvc.perform(
             get("/api/{departmentId}/list/{todayDate}", 4l, today.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"))));
+
+        //then
+        perform
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.length()").value(2));
+    }
+
+    @Test
+    void 부서_내_인원에_대한_출석체크를_반영한다() throws Exception {
+        //given
+        LocalDate today = LocalDate.of(2024, 1, 31);
+
+        DepartmentAttendanceMemberListRequest request = DepartmentAttendanceMemberListRequest.builder().build();
+
+        DepartmentAttendanceMemberListResponse response1 = DepartmentAttendanceMemberListResponse.builder()
+            .id(1l)
+            .name("test1")
+            .build();
+        DepartmentAttendanceMemberListResponse response2 = DepartmentAttendanceMemberListResponse.builder()
+            .id(2l)
+            .name("test2")
+            .build();
+
+        given(departmentService.attendanceDepartmentMember(anyLong(), any(DepartmentAttendanceMemberListRequest.class)))
+            .willReturn(List.of(response1, response2));
+
+        //when
+        ResultActions perform = mockMvc.perform(
+            post("/api/{departmentId}/attendance", 1l)
+                .content(objectMapper.writeValueAsString(request))
+                .contentType(MediaType.APPLICATION_JSON));
 
         //then
         perform


### PR DESCRIPTION
## 설명
- 부서 내 전체 인원 대상 출석체크 로직 작성
- 전달받은 인원(DepartmentAttendanceMemberListRequest), 부서 id(departmentId)로 출석체크 되는(absent/결석처리) 인원 조회/결석처리
- 테스트 코드 작성