### PR TITLE
feat: 전체 인원 리스트 필터 (#35)

### DIFF
--- a/src/main/java/ministryofeducation/sideprojectspring/config/QueryDslConfig.java
+++ b/src/main/java/ministryofeducation/sideprojectspring/config/QueryDslConfig.java
@@ -1,0 +1,20 @@
+package ministryofeducation.sideprojectspring.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+
+}

--- a/src/main/java/ministryofeducation/sideprojectspring/personnel/application/PersonnelService.java
+++ b/src/main/java/ministryofeducation/sideprojectspring/personnel/application/PersonnelService.java
@@ -12,6 +12,7 @@ import ministryofeducation.sideprojectspring.department.domain.Department;
 import ministryofeducation.sideprojectspring.department.infrastructure.DepartmentRepository;
 import ministryofeducation.sideprojectspring.personnel.domain.Personnel;
 import ministryofeducation.sideprojectspring.personnel.infrastructure.PersonnelRepository;
+import ministryofeducation.sideprojectspring.personnel.presentation.dto.request.PersonnelCondRequest;
 import ministryofeducation.sideprojectspring.personnel.presentation.dto.request.PersonnelPostRequest;
 import ministryofeducation.sideprojectspring.personnel.presentation.dto.response.PersonnelDetailResponse;
 import ministryofeducation.sideprojectspring.personnel.presentation.dto.response.PersonnelListResponse;
@@ -28,12 +29,8 @@ public class PersonnelService {
     private final DepartmentRepository departmentRepository;
     private final FileSaveToLocal fileSaveToLocal;
 
-    public List<PersonnelListResponse> personnelList() {
-        List<PersonnelListResponse> personnelListResponse = personnelRepository.findAll().stream()
-            .map(PersonnelListResponse::of)
-            .collect(Collectors.toList());
-
-        return personnelListResponse;
+    public List<PersonnelListResponse> personnelList(PersonnelCondRequest condition) {
+        return personnelRepository.findAllByCondition(condition);
     }
 
     public PersonnelDetailResponse personnelDetail(Long id) {

--- a/src/main/java/ministryofeducation/sideprojectspring/personnel/infrastructure/PersonnelCustomRepository.java
+++ b/src/main/java/ministryofeducation/sideprojectspring/personnel/infrastructure/PersonnelCustomRepository.java
@@ -1,0 +1,12 @@
+package ministryofeducation.sideprojectspring.personnel.infrastructure;
+
+import java.util.List;
+import ministryofeducation.sideprojectspring.personnel.domain.Personnel;
+import ministryofeducation.sideprojectspring.personnel.presentation.dto.request.PersonnelCondRequest;
+import ministryofeducation.sideprojectspring.personnel.presentation.dto.response.PersonnelListResponse;
+
+public interface PersonnelCustomRepository {
+
+    List<PersonnelListResponse> findAllByCondition(PersonnelCondRequest condition);
+
+}

--- a/src/main/java/ministryofeducation/sideprojectspring/personnel/infrastructure/PersonnelCustomRepositoryImpl.java
+++ b/src/main/java/ministryofeducation/sideprojectspring/personnel/infrastructure/PersonnelCustomRepositoryImpl.java
@@ -1,0 +1,63 @@
+package ministryofeducation.sideprojectspring.personnel.infrastructure;
+
+import static ministryofeducation.sideprojectspring.personnel.domain.QPersonnel.*;
+
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import ministryofeducation.sideprojectspring.personnel.domain.Personnel;
+import ministryofeducation.sideprojectspring.personnel.domain.QPersonnel;
+import ministryofeducation.sideprojectspring.personnel.domain.department_type.DepartmentType;
+import ministryofeducation.sideprojectspring.personnel.presentation.dto.request.PersonnelCondRequest;
+import ministryofeducation.sideprojectspring.personnel.presentation.dto.response.PersonnelListResponse;
+import org.springframework.stereotype.Repository;
+import org.springframework.util.StringUtils;
+
+@Repository
+@RequiredArgsConstructor
+public class PersonnelCustomRepositoryImpl implements PersonnelCustomRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<PersonnelListResponse> findAllByCondition(PersonnelCondRequest condition) {
+        return queryFactory
+            .select(Projections.constructor(PersonnelListResponse.class,
+                personnel.id,
+                personnel.name,
+                personnel.dateOfBirth,
+                personnel.phone,
+                personnel.address,
+                personnel.profileImage,
+                personnel.departmentType
+            ))
+            .where(departmentTypeEq(condition))
+            .from(personnel)
+            .fetch();
+    }
+
+    private BooleanExpression departmentTypeEq(PersonnelCondRequest condition){
+        return departmentType1Eq(condition.getDepartmentType1())
+            .or(departmentType2Eq(condition.getDepartmentType2()))
+            .or(departmentType3Eq(condition.getDepartmentType3()))
+            .or(departmentType4Eq(condition.getDepartmentType4()));
+    }
+
+    private BooleanExpression departmentType1Eq(DepartmentType departmentType){
+        return departmentType != null ? personnel.departmentType.eq(departmentType) : null;
+    }
+    private BooleanExpression departmentType2Eq(DepartmentType departmentType){
+        return departmentType != null ? personnel.departmentType.eq(departmentType) : null;
+    }
+    private BooleanExpression departmentType3Eq(DepartmentType departmentType){
+        return departmentType != null ? personnel.departmentType.eq(departmentType) : null;
+    }
+    private BooleanExpression departmentType4Eq(DepartmentType departmentType){
+        return departmentType != null ? personnel.departmentType.eq(departmentType) : null;
+    }
+
+}

--- a/src/main/java/ministryofeducation/sideprojectspring/personnel/infrastructure/PersonnelCustomRepositoryImpl.java
+++ b/src/main/java/ministryofeducation/sideprojectspring/personnel/infrastructure/PersonnelCustomRepositoryImpl.java
@@ -41,10 +41,10 @@ public class PersonnelCustomRepositoryImpl implements PersonnelCustomRepository 
     }
 
     private BooleanExpression departmentTypeEq(PersonnelCondRequest condition){
-        return departmentType1Eq(condition.getDepartmentType1())
+        return condition.getDepartmentType1() != null ? departmentType1Eq(condition.getDepartmentType1())
             .or(departmentType2Eq(condition.getDepartmentType2()))
             .or(departmentType3Eq(condition.getDepartmentType3()))
-            .or(departmentType4Eq(condition.getDepartmentType4()));
+            .or(departmentType4Eq(condition.getDepartmentType4())) : null;
     }
 
     private BooleanExpression departmentType1Eq(DepartmentType departmentType){

--- a/src/main/java/ministryofeducation/sideprojectspring/personnel/infrastructure/PersonnelRepository.java
+++ b/src/main/java/ministryofeducation/sideprojectspring/personnel/infrastructure/PersonnelRepository.java
@@ -8,9 +8,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-public interface PersonnelRepository extends JpaRepository<Personnel, Long> {
-
-    List<Personnel> findAll();
+public interface PersonnelRepository extends JpaRepository<Personnel, Long>, PersonnelCustomRepository {
 
     List<Personnel> findByDepartmentIdAndSmallGroupId(Long departmentId, Long smallGroupId);
 

--- a/src/main/java/ministryofeducation/sideprojectspring/personnel/presentation/PersonnelController.java
+++ b/src/main/java/ministryofeducation/sideprojectspring/personnel/presentation/PersonnelController.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import ministryofeducation.sideprojectspring.personnel.application.PersonnelService;
+import ministryofeducation.sideprojectspring.personnel.presentation.dto.request.PersonnelCondRequest;
 import ministryofeducation.sideprojectspring.personnel.presentation.dto.request.PersonnelPostRequest;
 import ministryofeducation.sideprojectspring.personnel.presentation.dto.response.PersonnelDetailResponse;
 import ministryofeducation.sideprojectspring.personnel.presentation.dto.response.PersonnelListResponse;
@@ -14,6 +15,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
@@ -26,8 +28,9 @@ public class PersonnelController {
     private final PersonnelService personnelService;
 
     @GetMapping("/list")
-    public ResponseEntity<List<PersonnelListResponse>> personnelList(){
-        List<PersonnelListResponse> responseDto = personnelService.personnelList();
+    public ResponseEntity<List<PersonnelListResponse>> personnelList(PersonnelCondRequest condition){
+        System.out.println("condition = " + condition.getDepartmentType1());
+        List<PersonnelListResponse> responseDto = personnelService.personnelList(condition);
 
         return ResponseEntity.ok(responseDto);
     }

--- a/src/main/java/ministryofeducation/sideprojectspring/personnel/presentation/dto/request/PersonnelCondRequest.java
+++ b/src/main/java/ministryofeducation/sideprojectspring/personnel/presentation/dto/request/PersonnelCondRequest.java
@@ -1,0 +1,28 @@
+package ministryofeducation.sideprojectspring.personnel.presentation.dto.request;
+
+import java.time.LocalDate;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import ministryofeducation.sideprojectspring.personnel.domain.department_type.DepartmentType;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PersonnelCondRequest {
+
+    private DepartmentType departmentType1;
+    private DepartmentType departmentType2;
+    private DepartmentType departmentType3;
+    private DepartmentType departmentType4;
+
+    @Builder
+    public PersonnelCondRequest(DepartmentType departmentType1, DepartmentType departmentType2,
+        DepartmentType departmentType3, DepartmentType departmentType4) {
+        this.departmentType1 = departmentType1;
+        this.departmentType2 = departmentType2;
+        this.departmentType3 = departmentType3;
+        this.departmentType4 = departmentType4;
+    }
+}

--- a/src/test/java/ministryofeducation/sideprojectspring/config/TestQueryDslConfig.java
+++ b/src/test/java/ministryofeducation/sideprojectspring/config/TestQueryDslConfig.java
@@ -1,0 +1,20 @@
+package ministryofeducation.sideprojectspring.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+@TestConfiguration
+public class TestQueryDslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+
+}

--- a/src/test/java/ministryofeducation/sideprojectspring/unit/Personnel/application/PersonnelServiceTest.java
+++ b/src/test/java/ministryofeducation/sideprojectspring/unit/Personnel/application/PersonnelServiceTest.java
@@ -1,6 +1,7 @@
 package ministryofeducation.sideprojectspring.unit.Personnel.application;
 
 import static ministryofeducation.sideprojectspring.factory.PersonnelFactory.*;
+import static ministryofeducation.sideprojectspring.personnel.domain.department_type.DepartmentType.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 import static org.mockito.Mockito.*;
@@ -19,6 +20,7 @@ import ministryofeducation.sideprojectspring.personnel.application.PersonnelServ
 import ministryofeducation.sideprojectspring.personnel.domain.Personnel;
 import ministryofeducation.sideprojectspring.personnel.domain.department_type.DepartmentType;
 import ministryofeducation.sideprojectspring.personnel.infrastructure.PersonnelRepository;
+import ministryofeducation.sideprojectspring.personnel.presentation.dto.request.PersonnelCondRequest;
 import ministryofeducation.sideprojectspring.personnel.presentation.dto.request.PersonnelPostRequest;
 import ministryofeducation.sideprojectspring.personnel.presentation.dto.response.PersonnelDetailResponse;
 import ministryofeducation.sideprojectspring.personnel.presentation.dto.response.PersonnelListResponse;
@@ -54,26 +56,33 @@ class PersonnelServiceTest {
     @Test
     public void 전체_인원을_조회한다() {
         //given
-        Personnel personnel1 = testPersonnel(1l, "test1", "test1@email.com", "010-0000-0001");
-        Personnel personnel2 = testPersonnel(2l, "test2", "test2@email.com", "010-0000-0002");
-        Personnel personnel3 = testPersonnel(3l, "test3", "test3@email.com", "010-0000-0003");
-        List<Personnel> personnelList = List.of(personnel1, personnel2, personnel3);
+        PersonnelListResponse response1 = PersonnelListResponse.builder()
+            .name("test1")
+            .phone("010-0000-0001")
+            .build();
+        PersonnelListResponse response2 = PersonnelListResponse.builder()
+            .name("test2")
+            .phone("010-0000-0002")
+            .build();
 
-        given(personnelRepository.findAll()).willReturn(personnelList);
+        PersonnelCondRequest condition = PersonnelCondRequest.builder().build();
+
+        given(personnelRepository.findAllByCondition(condition)).willReturn(
+            List.of(response1, response2)
+        );
 
         //when
-        List<PersonnelListResponse> personnelListResponse = personnelService.personnelList();
+        List<PersonnelListResponse> personnelListResponse = personnelService.personnelList(condition);
 
         //then
-        assertThat(personnelListResponse).hasSize(3)
+        assertThat(personnelListResponse).hasSize(2)
             .extracting("name", "phone")
             .containsExactlyInAnyOrder(
                 tuple("test1", "010-0000-0001"),
-                tuple("test2", "010-0000-0002"),
-                tuple("test3", "010-0000-0003")
+                tuple("test2", "010-0000-0002")
             );
 
-        verify(personnelRepository, times(1)).findAll();
+        verify(personnelRepository, times(1)).findAllByCondition(condition);
     }
 
     @Test
@@ -96,7 +105,7 @@ class PersonnelServiceTest {
         //given
         PersonnelPostRequest personnelPostRequest = PersonnelPostRequest.builder()
             .name("test")
-            .departmentType(DepartmentType.JOSHUA)
+            .departmentType(JOSHUA)
             .dateOfBirth(LocalDate.of(1997, 8, 26))
             .phone("010-0000-0000")
             .email("test@email.com")

--- a/src/test/java/ministryofeducation/sideprojectspring/unit/Personnel/infrastructure/AttendanceRepositoryTest.java
+++ b/src/test/java/ministryofeducation/sideprojectspring/unit/Personnel/infrastructure/AttendanceRepositoryTest.java
@@ -2,11 +2,10 @@ package ministryofeducation.sideprojectspring.unit.Personnel.infrastructure;
 
 import static ministryofeducation.sideprojectspring.personnel.domain.attendance.AttendanceCheck.*;
 import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
 
 import java.time.LocalDate;
 import java.util.List;
-import java.util.Optional;
+import ministryofeducation.sideprojectspring.config.TestQueryDslConfig;
 import ministryofeducation.sideprojectspring.department.domain.Department;
 import ministryofeducation.sideprojectspring.department.infrastructure.DepartmentRepository;
 import ministryofeducation.sideprojectspring.personnel.domain.Attendance;
@@ -14,18 +13,16 @@ import ministryofeducation.sideprojectspring.personnel.domain.Personnel;
 import ministryofeducation.sideprojectspring.personnel.domain.attendance.AttendanceCheck;
 import ministryofeducation.sideprojectspring.personnel.infrastructure.AttendanceRepository;
 import ministryofeducation.sideprojectspring.personnel.infrastructure.PersonnelRepository;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.transaction.annotation.Propagation;
-import org.springframework.transaction.annotation.Transactional;
 
 @DataJpaTest
-@Transactional(propagation = Propagation.NOT_SUPPORTED)
 @ActiveProfiles("test")
+@Import(TestQueryDslConfig.class)
 class AttendanceRepositoryTest {
 
     @Autowired
@@ -44,7 +41,6 @@ class AttendanceRepositoryTest {
         LocalDate recentDate = LocalDate.of(2024, 1, 30);
 
         Personnel personnel = Personnel.builder()
-            .id(1l)
             .name("test")
             .build();
         personnelRepository.save(personnel);
@@ -55,7 +51,7 @@ class AttendanceRepositoryTest {
             .build();
         departmentRepository.save(department);
 
-        Attendance attendance = Attendance.createAttendance(1l, recentDate, ABSENT, department, personnel);
+        Attendance attendance = buildAttendance(recentDate, personnel, department, ABSENT);
         attendanceRepository.save(attendance);
 
         //when
@@ -74,15 +70,12 @@ class AttendanceRepositoryTest {
         LocalDate testDate = LocalDate.of(2024, 1, 30);
 
         Personnel personnel1 = Personnel.builder()
-            .id(1l)
             .name("test1")
             .build();
         Personnel personnel2 = Personnel.builder()
-            .id(2l)
             .name("test2")
             .build();
         Personnel personnel3 = Personnel.builder()
-            .id(3l)
             .name("test3")
             .build();
         personnelRepository.saveAll(List.of(personnel1, personnel2, personnel3));
@@ -93,9 +86,10 @@ class AttendanceRepositoryTest {
             .build();
         departmentRepository.save(department);
 
-        Attendance attendance1 = Attendance.createAttendance(1l, testDate, ATTENDANCE, department, personnel1);
-        Attendance attendance2 = Attendance.createAttendance(2l, testDate, ATTENDANCE, department, personnel2);
-        Attendance attendance3 = Attendance.createAttendance(3l, testDate, ABSENT, department, personnel3);
+        Attendance attendance1 = buildAttendance(testDate, personnel1, department, ATTENDANCE);
+        Attendance attendance2 = buildAttendance(testDate, personnel2, department, ATTENDANCE);
+        Attendance attendance3 = buildAttendance(testDate, personnel3, department, ABSENT);
+
         attendanceRepository.saveAll(List.of(attendance1, attendance2, attendance3));
 
         //when
@@ -105,4 +99,15 @@ class AttendanceRepositoryTest {
         //then
         assertThat(attendanceCount).isEqualTo(2l);
     }
+
+    private Attendance buildAttendance(LocalDate recentDate, Personnel personnel, Department department,
+        AttendanceCheck attendanceCheck) {
+        return Attendance.builder()
+            .attendanceDate(recentDate)
+            .attendanceCheck(attendanceCheck)
+            .department(department)
+            .personnel(personnel)
+            .build();
+    }
+
 }

--- a/src/test/java/ministryofeducation/sideprojectspring/unit/Personnel/presentation/PersonnelControllerTest.java
+++ b/src/test/java/ministryofeducation/sideprojectspring/unit/Personnel/presentation/PersonnelControllerTest.java
@@ -11,6 +11,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.util.List;
 import ministryofeducation.sideprojectspring.personnel.domain.department_type.DepartmentType;
+import ministryofeducation.sideprojectspring.personnel.presentation.dto.request.PersonnelCondRequest;
 import ministryofeducation.sideprojectspring.personnel.presentation.dto.request.PersonnelPostRequest;
 import ministryofeducation.sideprojectspring.personnel.presentation.dto.response.PersonnelDetailResponse;
 import ministryofeducation.sideprojectspring.personnel.presentation.dto.response.PersonnelListResponse;
@@ -36,7 +37,7 @@ class PersonnelControllerTest extends ControllerTest {
             PersonnelListResponse.of(testPersonnel(3l, "test3", "test3@email.com"))
         );
 
-        given(personnelService.personnelList()).willReturn(personnelListResponse);
+        given(personnelService.personnelList(any())).willReturn(personnelListResponse);
 
         String response = objectMapper.writeValueAsString(personnelListResponse);
 

--- a/src/test/java/ministryofeducation/sideprojectspring/unit/department/infrastructure/SmallGroupRepositoryTest.java
+++ b/src/test/java/ministryofeducation/sideprojectspring/unit/department/infrastructure/SmallGroupRepositoryTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.List;
+import ministryofeducation.sideprojectspring.config.TestQueryDslConfig;
 import ministryofeducation.sideprojectspring.department.domain.Department;
 import ministryofeducation.sideprojectspring.department.domain.SmallGroup;
 import ministryofeducation.sideprojectspring.department.infrastructure.DepartmentRepository;
@@ -14,10 +15,12 @@ import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 
 @DataJpaTest
 @ActiveProfiles("test")
+@Import(TestQueryDslConfig.class)
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class SmallGroupRepositoryTest {
 


### PR DESCRIPTION
## 설명
- 전체 인원 필터 기능 추가
- queryDsl 사용하여 동적 쿼리 처리
- 부서 별 인원 목록 조회 가능하도록 함 (여러 부서 선택 시 해당하는 부서 모든 인원 조회)
- 테스트 작성